### PR TITLE
rootdev: Strip partitions less aggressively

### DIFF
--- a/src/rootdev/rootdev.c
+++ b/src/rootdev/rootdev.c
@@ -204,10 +204,18 @@ void rootdev_strip_partition(char *dst, size_t len) {
   char *part = (char *)rootdev_get_partition(dst, len);
   if (!part)
     return;
+
+  /* For devices matching dm-NN, the digits are not a partition. */
+  if (*(part - 1) == '-')
+    return;
+
   /* For devices that end with a digit, the kernel uses a 'p'
-   * as a separator. E.g., mmcblk1p2. */
-  if (*(part - 1) == 'p')
+   * as a separator. E.g., mmcblk1p2 and loop0p1, but not loop0. */
+  if (*(part - 1) == 'p') {
     part--;
+    if (strncmp(dst, "loop", 4) == 0 && dst + 3 == part)
+      return;
+  }
   *part = '\0';
 }
 


### PR DESCRIPTION
In device names like dm-N or loopN, the N is not a partition number and
should not be stripped off.  These can arise for example if run inside a
chroot mounted on a loopback device.

BUG=chromium:748665, chromium:730144
TEST=New unit tests.

Change-Id: If7ecacbfcf00690376cb4ffc75baa45422579085
Reviewed-on: https://chromium-review.googlesource.com/585652
Commit-Ready: Benjamin Gordon <bmgordon@chromium.org>
Tested-by: Benjamin Gordon <bmgordon@chromium.org>
Reviewed-by: Simon Glass <sjg@chromium.org>
Reviewed-by: Mike Frysinger <vapier@chromium.org>
Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# pulling in upstream commit 

https://chromium.googlesource.com/chromiumos/third_party/rootdev/+/fc570685c1ca4acb871c706a66d0493b5e92c7c9

# How to use

[ describe what reviewers need to do in order to validate this PR ]


# Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
