### PR TITLE
fix(cgpt): get an aligned variable

### DIFF
--- a/src/cgpt/cgpt_add.c
+++ b/src/cgpt/cgpt_add.c
@@ -94,7 +94,9 @@ static int GptSetEntryAttributes(struct drive *drive,
   if (params->set_type)
     memcpy(&entry->type, &params->type_guid, sizeof(Guid));
   if (params->label) {
-    if (CGPT_OK != UTF8ToUTF16((uint8_t *)params->label, entry->name,
+    uint16_t name[36];
+    memcpy(name, entry->name, sizeof(uint16_t)*36);
+    if (CGPT_OK != UTF8ToUTF16((uint8_t *)params->label, name,
                                sizeof(entry->name) / sizeof(entry->name[0]))) {
       Error("The label cannot be converted to UTF16.\n");
       return -1;

--- a/src/cgpt/cgpt_find.c
+++ b/src/cgpt/cgpt_find.c
@@ -113,7 +113,9 @@ static int do_search(CgptFindParams *params, char *fileName) {
         || (params->set_type && GuidEqual(&params->type_guid, &entry->type))) {
       found = 1;
     } else if (params->set_label) {
-      if (CGPT_OK != UTF16ToUTF8(entry->name,
+      uint16_t name[36];
+      memcpy(name, entry->name, sizeof(uint16_t)*36);
+      if (CGPT_OK != UTF16ToUTF8(name,
                                  sizeof(entry->name) / sizeof(entry->name[0]),
                                  (uint8_t *)partlabel, sizeof(partlabel))) {
         Error("The label cannot be converted from UTF16, so abort.\n");

--- a/src/cgpt/cgpt_show.c
+++ b/src/cgpt/cgpt_show.c
@@ -100,7 +100,9 @@ void EntryDetails(GptEntry *entry, uint32_t index, int raw) {
   if (!raw) {
     char type[GUID_STRLEN], unique[GUID_STRLEN];
 
-    UTF16ToUTF8(entry->name, sizeof(entry->name) / sizeof(entry->name[0]),
+    uint16_t name[36];
+    memcpy(name, entry->name, sizeof(uint16_t)*36);
+    UTF16ToUTF8(name, sizeof(entry->name) / sizeof(entry->name[0]),
                 label, sizeof(label));
     require(snprintf(contents, sizeof(contents),
                      "Label: \"%s\"", label) < sizeof(contents));
@@ -137,7 +139,9 @@ void EntryDetails(GptEntry *entry, uint32_t index, int raw) {
   } else {
     char type[GUID_STRLEN], unique[GUID_STRLEN];
 
-    UTF16ToUTF8(entry->name, sizeof(entry->name) / sizeof(entry->name[0]),
+    uint16_t name[36];
+    memcpy(name, entry->name, sizeof(uint16_t)*36);
+    UTF16ToUTF8(name, sizeof(entry->name) / sizeof(entry->name[0]),
                 label, sizeof(label));
     require(snprintf(contents, sizeof(contents),
                      "Label: \"%s\"", label) < sizeof(contents));
@@ -232,6 +236,7 @@ int CgptShow(CgptShowParams *params) {
     GptEntry *entry = GetEntry(&drive.gpt, ANY_VALID, index);
     char buf[256];                      // scratch buffer for string conversion
 
+    uint16_t name[36];
     if (params->single_item) {
       switch(params->single_item) {
       case 'b':
@@ -249,7 +254,8 @@ int CgptShow(CgptShowParams *params) {
         printf("%s\n", buf);
         break;
       case 'l':
-        UTF16ToUTF8(entry->name, sizeof(entry->name) / sizeof(entry->name[0]),
+        memcpy(name, entry->name, sizeof(uint16_t)*36);
+        UTF16ToUTF8(name, sizeof(entry->name) / sizeof(entry->name[0]),
                     (uint8_t *)buf, sizeof(buf));
         printf("%s\n", buf);
         break;


### PR DESCRIPTION
Since the GptEntry is packed, the pointer is possibly unaligned.

This has been a warning, but on gcc 9.3 it errors.

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# fixes the compiler error due to aligning to a packed struct


# How to use

[ describe what reviewers need to do in order to validate this PR ]


# Testing done

compiling and running the `rootdev` command
