### PR TITLE
Fix setting the label

### DIFF
--- a/src/cgpt/cgpt_add.c
+++ b/src/cgpt/cgpt_add.c
@@ -95,12 +95,12 @@ static int GptSetEntryAttributes(struct drive *drive,
     memcpy(&entry->type, &params->type_guid, sizeof(Guid));
   if (params->label) {
     uint16_t name[36];
-    memcpy(name, entry->name, sizeof(uint16_t)*36);
     if (CGPT_OK != UTF8ToUTF16((uint8_t *)params->label, name,
                                sizeof(entry->name) / sizeof(entry->name[0]))) {
       Error("The label cannot be converted to UTF16.\n");
       return -1;
     }
+    memcpy(entry->name, name, sizeof(uint16_t)*36);
   }
   return 0;
 }


### PR DESCRIPTION
In fdef685450ef7c31ea469285913f5914a4431a6f a logical bug was introduced
which caused the label to be never set.
Copy the content of the temporary "name" buffer to entry->name after
name was filled by the UTF16 converted params->label.


# How to use

```
./autogen.sh
./configure
make
```

# Testing done

```
$ ./cgpt show /var/tmp/flatcar-debug/flatcar_production_image.bin
       start        size    part  contents
           0           1          Hybrid MBR
           1           1          Pri GPT header
           2          32          Pri GPT table
        4096      262144       1  Label: ""
                                  Type: EFI System Partition
                                  UUID: C59D3699-0325-45C2-8D41-025A69A29AFB
                                  Attr: Legacy BIOS Bootable
      266240        4096       2  Label: ""
                                  Type: BIOS Boot Partition
                                  UUID: 26BC5CFB-9287-4A80-9A69-EF4626B697CB
      270336     2097152       3  Label: ""
                                  Type: Alias for coreos-rootfs
                                  UUID: 7130C94A-213A-4E5A-8E26-6CCE9662F132
                                  Attr: priority=1 tries=0 successful=1
     2367488     2097152       4  Label: ""
                                  Type: Alias for coreos-rootfs
                                  UUID: E03DD35C-7C2D-4A47-B3FE-27F15780A57C
                                  Attr: priority=0 tries=0 successful=0
     4464640      262144       6  Label: ""
                                  Type: Alias for linux-data
                                  UUID: 30EE3EB1-09AC-4FE1-B545-E43CCCE43AB4
     4726784      131072       7  Label: ""
                                  Type: CoreOS reserved
                                  UUID: 0901E065-A378-42B9-AD85-90B630D88DFE
     4857856     4427776       9  Label: ""
                                  Type: CoreOS auto-resize
                                  UUID: 7427A941-4910-4601-9F15-88AF1B92C0F2
     9289695          32          Sec GPT table
     9289727           1          Sec GPT header
[kai@kai seismograph]$ ./cgpt add -i 9 -l ROOT /var/tmp/flatcar-debug/flatcar_production_image.bin
[kai@kai seismograph]$ ./cgpt show /var/tmp/flatcar-debug/flatcar_production_image.bin
       start        size    part  contents
           0           1          Hybrid MBR
           1           1          Pri GPT header
           2          32          Pri GPT table
        4096      262144       1  Label: ""
                                  Type: EFI System Partition
                                  UUID: C59D3699-0325-45C2-8D41-025A69A29AFB
                                  Attr: Legacy BIOS Bootable
      266240        4096       2  Label: ""
                                  Type: BIOS Boot Partition
                                  UUID: 26BC5CFB-9287-4A80-9A69-EF4626B697CB
      270336     2097152       3  Label: ""
                                  Type: Alias for coreos-rootfs
                                  UUID: 7130C94A-213A-4E5A-8E26-6CCE9662F132
                                  Attr: priority=1 tries=0 successful=1
     2367488     2097152       4  Label: ""
                                  Type: Alias for coreos-rootfs
                                  UUID: E03DD35C-7C2D-4A47-B3FE-27F15780A57C
                                  Attr: priority=0 tries=0 successful=0
     4464640      262144       6  Label: ""
                                  Type: Alias for linux-data
                                  UUID: 30EE3EB1-09AC-4FE1-B545-E43CCCE43AB4
     4726784      131072       7  Label: ""
                                  Type: CoreOS reserved
                                  UUID: 0901E065-A378-42B9-AD85-90B630D88DFE
     4857856     4427776       9  Label: "ROOT"
                                  Type: CoreOS auto-resize
                                  UUID: 7427A941-4910-4601-9F15-88AF1B92C0F2
     9289695          32          Sec GPT table
     9289727           1          Sec GPT header

```