### PR TITLE
rootdev: support btrfs

### DIFF
--- a/include/rootdev/rootdev.h
+++ b/include/rootdev/rootdev.h
@@ -95,6 +95,7 @@ const char *rootdev_get_partition(const char *dst, size_t len);
 void rootdev_strip_partition(char *dst, size_t len);
 int rootdev_symlink_active(const char *path);
 int rootdev_create_devices(const char *name, dev_t dev, bool symlink);
+dev_t rootdev_devt_from_mountpoint(const char *path);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/src/cgpt/cgpt_next.c
+++ b/src/cgpt/cgpt_next.c
@@ -41,7 +41,7 @@ static int do_search(CgptNextParams *params) {
     successful = GetSuccessful(&drive, PRIMARY, i);
 
     if (next_index == -1 || ((priority > next_priority) && (successful || tries))) {
-      strncpy(next_file_name, params->drive_name, BUFSIZE);
+      strncpy(next_file_name, params->drive_name, BUFSIZE-1);
       next_file_name[BUFSIZE - 1] = '\0';
       if (successful || tries) {
         next_priority = priority;

--- a/src/rootdev/main.c
+++ b/src/rootdev/main.c
@@ -126,10 +126,15 @@ int main(int argc, char **argv) {
   if (flag_major || flag_minor) {
     root_dev = makedev(flag_major, flag_minor);
   } else {
-    /* Yields the containing dev_t in st_dev. */
-    if (stat(flag_path, &path_stat) != 0)
-      err(1, "Cannot stat(%s)", flag_path);
-    root_dev = path_stat.st_dev;
+    root_dev = rootdev_devt_from_mountpoint(flag_path);
+    /* First search by mount point which works for btrfs and normal file systems,
+       then fall back to old behavior for propper error reporting */
+    if (root_dev == 0) {
+      /* Yields the containing dev_t in st_dev. */
+      if (stat(flag_path, &path_stat) != 0)
+        err(1, "Cannot stat(%s)", flag_path);
+      root_dev = path_stat.st_dev;
+    }
   }
 
   path[0] = '\0';


### PR DESCRIPTION
- rootdev: support btrfs
    
    With btrfs it's not possible in general to find a single underlying
    block device because there could be many, but still it is possible for
    our case since we have a single partition. However, rootdev failed to
    find it because it uses the device minor and major pair from a "stat"
    syscall on the mount point. This doesn't work with btrfs because it
    gives a logical pair instead of one belonging to a block device.
    
    Instead of using the minor and major pair, find the underlying block
    device of a mount point by looking it up in /proc/mounts. The existing
    traversal code to find the lowest backing device is kept in place by
    getting the minor and major pair for the found block device.
- cgpt: fix cause for compiler warning

## How to use/Testing done

This was built and tested with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131 in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ where the Flatcar image that has a btrfs /usr partition and OEM partition.
While the actual switch to a btrfs filesystem on the /usr partition is only possible when all changes are part of a Stable release because update-engine needs to know how to handle the new filesystem when updating, we can already do the switch for the OEM partition.