### PR TITLE
Mirror upstream CHS values for PMBR

### DIFF
--- a/src/cgpt/cgpt_common.c
+++ b/src/cgpt/cgpt_common.c
@@ -1056,7 +1056,7 @@ static void fill_part(struct legacy_partition *part, enum mbr_type type,
    * values that parted does. May help avoid boot issues on some systems. */
   if (type == MBR_PROTECTIVE) {
     part->f_chs[0] = 0x00;
-    part->f_chs[1] = 0x01;
+    part->f_chs[1] = 0x02;
     part->f_chs[2] = 0x00;
   } else {
     compute_chs(part->f_chs, starting_lba);
@@ -1064,7 +1064,7 @@ static void fill_part(struct legacy_partition *part, enum mbr_type type,
   part->f_lba = htole32((uint32_t)starting_lba);
 
   if (type == MBR_PROTECTIVE) {
-    part->l_chs[0] = 0xfe;
+    part->l_chs[0] = 0xff;
     part->l_chs[1] = 0xff;
     part->l_chs[2] = 0xff;
   } else {


### PR DESCRIPTION
# Mirror upstream CHS values for PMBR

This change mirrors the [upstream CHS values](https://chromium.googlesource.com/chromiumos/platform/vboot_reference/+/refs/heads/main/cgpt/cgpt_boot.c#95) in the case of PMBR.

## How to use

Update the flatcar SDK to include this change, generate a new image and verify that the CHS fields are set to the values described in this patch.

## Testing done

Locally generated a new image and checked the CHS values via:

```python
>>> import struct
>>> img = open("flatcar_production_openstack_image.raw", 'rb')
>>> img.seek(446)
>>> data = img.read(16)
>>> (boot_flag, f_head, f_sect, f_cyl,
 type, l_head, l_sect, l_cyl, f_lba,
 num_sect) = struct.unpack('<B3BB3BII', data)
>>> (f_head, f_sect, f_cyl) == (0, 2, 0)
True
```