### PR TITLE
Update CI workflow to trigger on main branch instead of flatcar-master

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,9 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ flatcar-master ]
+    branches: [ main ]
   pull_request:
-    branches: [ flatcar-master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/c-cpp.yml` file. The change updates the branch names in the C/C++ CI workflow configuration from `flatcar-master` to `main`.

Part of: https://github.com/flatcar/Flatcar/issues/1714